### PR TITLE
docs: clarify native OpenClaw plugin installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,18 @@ Environment variables are resolved from `~/.openclaw/.env` and system env.
 #            hetzner, miro, wise, tavily, apify
 ```
 
+## Native OpenClaw Plugins
+
+Use this bridge for integrations that expose MCP servers. If an integration already ships as an OpenClaw plugin, install it directly so OpenClaw can load its plugin manifest, skills, config schema, and update flow.
+
+For example, [TweetClaw](https://github.com/Xquik-dev/tweetclaw) is published as the native OpenClaw plugin [@xquik/tweetclaw](https://www.npmjs.com/package/@xquik/tweetclaw), so install it directly instead of adding it to `servers`:
+
+```bash
+openclaw plugins install @xquik/tweetclaw
+```
+
+TweetClaw gives agents tools for search tweets, search tweet replies, post tweets, post tweet replies, follower export, user lookup, media upload and download, direct messages, monitor tweets, webhooks, and giveaway draws through its plugin config.
+
 ## Docker Sandbox
 
 If you run OpenClaw with Docker sandbox enabled (`agents.defaults.sandbox.mode: "all"` or `"non-main"`), plugin-registered tools are **not included** in the default sandbox tool allowlist. You need to explicitly allow them:

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "openclaw-mcp-bridge",
   "name": "openclaw-mcp-bridge",
-  "version": "0.11.6",
+  "version": "0.14.0",
   "entryPoint": "index.ts",
   "skills": ["skills/"],
   "configSchema": {


### PR DESCRIPTION
## Summary
- Add README guidance for when OpenClaw users should install a native plugin directly instead of configuring it as an MCP server through this bridge.
- Use TweetClaw as a concrete native OpenClaw plugin example for X/Twitter automation workflows such as search tweets, tweet replies, follower export, user lookup, media, direct messages, monitors, webhooks, and giveaway draws.
- Refresh the branch on top of upstream `master` at `0.14.1` and keep the upstream manifest version.

Fixes #8.

## Validation
- `git diff --check`
- README, package metadata, and manifest link sweep: 15 links checked, 11 OK, 4 expected blockers from npmjs.com bot protection and local OpenClaw config URL example
- package and OpenClaw manifest version parity check
- `npm view @xquik/tweetclaw version openclaw.install` returned `1.6.31` and npm-first install metadata
- `npm ci`
- `npm run build`
- `npm run check:manifest-version`
- `npm run check:esm-load`
- `npm run typecheck`
- `npm test`
- `npm pack --dry-run --json`
